### PR TITLE
add rust libs to android build

### DIFF
--- a/mobile-app/android/app/build.gradle
+++ b/mobile-app/android/app/build.gradle
@@ -66,3 +66,10 @@ android {
 flutter {
     source = "../.."
 }
+
+// Apply cargokit directly to the main app
+apply from: "../../../quantus_sdk/rust_builder/cargokit/gradle/plugin.gradle"
+cargokit {
+    manifestDir = "../../../quantus_sdk/rust"
+    libname = "rust_lib_resonance_network_wallet"
+}

--- a/quantus_sdk/rust_builder/cargokit/gradle/plugin.gradle
+++ b/quantus_sdk/rust_builder/cargokit/gradle/plugin.gradle
@@ -95,7 +95,7 @@ class CargoKitPlugin implements Plugin<Project> {
    private Plugin _findFlutterPlugin(Map projects) {
         for (project in projects) {
             for (plugin in project.value.getPlugins()) {
-                if (plugin.class.name == "FlutterPlugin") {
+                if (plugin.class.name == "FlutterPlugin" || plugin.class.name == "com.flutter.gradle.FlutterPlugin") {
                     return plugin;
                 }
             }
@@ -132,7 +132,8 @@ class CargoKitPlugin implements Plugin<Project> {
             def jniLibs = project.android.sourceSets.maybeCreate(buildType).jniLibs;
             jniLibs.srcDir(new File(cargoOutputDir))
 
-            def platforms = plugin.getTargetPlatforms().collect()
+            // Modern Flutter plugin doesn't have getTargetPlatforms, use standard Android platforms
+            def platforms = ["android-arm", "android-arm64"]
 
             // Same thing addFlutterDependencies does in flutter.gradle
             if (buildType == "debug") {


### PR DESCRIPTION
## Problem

Android build was crashing due to the changes in the project setup, it would not actually build the rust bindings native libraries and crash on startup. 

The build was building fine though, so good @dewabisma was testing it out. 

## Fixed Screenshot

<img width="448" alt="image" src="https://github.com/user-attachments/assets/31f31d56-2e13-49fb-a4f4-9b4b586dbffb" />

## Error
Fix for this error
```
Running Gradle task 'assembleDebug'...                             27.1s
✓ Built build/app/outputs/flutter-apk/app-debug.apk
Installing build/app/outputs/flutter-apk/app-debug.apk...        1,245ms
I/flutter ( 5150): [IMPORTANT:flutter/shell/platform/android/android_context_gl_impeller.cc(94)] Using the Impeller rendering backend (OpenGLES).
I/flutter ( 5150): Initial connection failed: Exception: Already connected
I/flutter ( 5150): initializing rust bindings..
E/flutter ( 5150): [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: Invalid argument(s): Failed to load dynamic library 'librust_lib_resonance_network_wallet.so': dlopen failed: library "librust_lib_resonance_network_wallet.so" not found
E/flutter ( 5150): #0      _open (dart:ffi-patch/ffi_dynamic_library_patch.dart:11:43)
E/flutter ( 5150): #1      new DynamicLibrary.open (dart:ffi-patch/ffi_dynamic_library_patch.dart:22:12)
E/flutter ( 5150): #2      new ExternalLibrary.open (package:flutter_rust_bridge/src/platform_types/_io.dart:42:47)
E/flutter ( 5150): #3      loadExternalLibraryRaw (package:flutter_rust_bridge/src/loader/_io.dart:56:28)
E/flutter ( 5150): #4      loadExternalLibrary (package:flutter_rust_bridge/src/loader/_io.dart:14:10)
E/flutter ( 5150): #5      BaseEntrypoint._loadDefaultExternalLibrary (package:flutter_rust_bridge/src/main_components/entrypoint.dart:141:13)
E/flutter ( 5150): #6      BaseEntrypoint.initImpl (package:flutter_rust_bridge/src/main_components/entrypoint.dart:48:31)
E/flutter ( 5150): #7      RustLib.init (package:quantus_sdk/src/rust/frb_generated.dart:27:20)
E/flutter ( 5150): #8      QuantusSdk.init (package:quantus_sdk/quantus_sdk.dart:24:19)
E/flutter ( 5150): #9      main (package:resonance_network_wallet/main.dart:8:20)
E/flutter ( 5150): <asynchronous suspension>
E/flutter ( 5150): 
I/.quantus.wallet( 5150): Compiler allocated 5111KB to compile void android.view.ViewRootImpl.performTraversals()
I/WindowExtensionsImpl( 5150): Initializing Window Extensions, vendor API level=9, activity embedding enabled=true
Syncing files to device sdk gphone64 arm64...                      688ms
```